### PR TITLE
fix(statistic): #MBA-97 fix most refused badges style

### DIFF
--- a/scss/specifics/minibadge/containers/_statistics.scss
+++ b/scss/specifics/minibadge/containers/_statistics.scss
@@ -102,7 +102,20 @@
 
       .minibadge-most-assigned {
         padding: 10px;
-        align-items: stretch;
+        align-items: center;
+
+        &-detail {
+          flex: 3;
+        }
+
+        &-others {
+          flex: 3;
+        }
+
+        minibadge-card-type {
+          flex: 2;
+        }
+
       }
     }
 
@@ -117,7 +130,7 @@
     minibadge-card-type {
       .minibadge-card {
         height: 176px;
-        width: 176px;
+        width: 100%;
       }
     }
 


### PR DESCRIPTION
## Description

Faire en sorte que la liste des badges les plus refusés ne dépasse pas l'écran (notamment pour les petits écrans).