### PR TITLE
fix(statistic): #MBA-97 fix badge size inside cards

### DIFF
--- a/scss/specifics/minibadge/components/_card.scss
+++ b/scss/specifics/minibadge/components/_card.scss
@@ -73,6 +73,7 @@
 .minibadge-card-simple, minibadge-card-type-statistic {
   display: flex;
   align-self: center;
+  flex: 1 1 0;
 
   .minibadge-card {
     @include desktop {


### PR DESCRIPTION
## Description
Réajustage de la taille des badges afin qu'ils soient uniformes (en lien avec le ticket précédent ayant le même flag:
 [PR-10](https://github.com/CGI-OPEN-ENT-NG/entcore-css-lib/pull/10))