### PR TITLE
fix(lists): #MBA-104 fix lists style distinctions to keep centered.

### DIFF
--- a/scss/specifics/minibadge/components/_list.scss
+++ b/scss/specifics/minibadge/components/_list.scss
@@ -10,6 +10,10 @@
     align-items: center;
     overflow: hidden;
 
+    &-number {
+      align-self: baseline;
+    }
+
     &-img {
       margin-top: 0;
       padding: 5px 0;
@@ -22,6 +26,10 @@
 
     &-distinction {
       color: $minibadge-grey;
+      flex-shrink: 0;
+      &-italic {
+        font-style: italic;
+      }
     }
 
   }


### PR DESCRIPTION
## Description
Sur les différentes listes du module (et spécifiquement à partir de la liste des "utilisateurs les plus généreux" de statistique), faire en sorte que lorsque le nom est long, le numéro de liste reste en haut, et la distinction reste au centre.

en lien avec la PR: https://github.com/CGI-OPEN-ENT-NG/minibadge/pull/73