### PR TITLE
fix(type): #MBA-108 allow badge to stay at the top in badge type detail

### DIFF
--- a/scss/specifics/minibadge/components/_card.scss
+++ b/scss/specifics/minibadge/components/_card.scss
@@ -73,7 +73,6 @@
 .minibadge-card-simple, minibadge-card-type-statistic {
   display: flex;
   align-self: center;
-  flex: 1 1 0;
 
   .minibadge-card {
     @include desktop {


### PR DESCRIPTION
## Description
Garde le badge en haut de son container (sur la page de détail d'un badge)

[PR - Minibadge](https://github.com/CGI-OPEN-ENT-NG/minibadge/pull/77)