### PR TITLE
fix(statistics): #MA-1056 set cells flexible, depending on row size, on global indicator table.

### DIFF
--- a/scss/specifics/statistics-presences/indicators/_global.scss
+++ b/scss/specifics/statistics-presences/indicators/_global.scss
@@ -43,11 +43,14 @@
 
   .reload {
     cursor: pointer;
+
     &:hover {
       color: $statistics-presences-main;
     }
+
     &.disabled {
       color: $statistics-presences-middle-grey;
+
       &:hover {
         color: $statistics-presences-middle-grey;
       }
@@ -56,8 +59,18 @@
 
   .flex-row {
     min-height: 0 !important;
-    padding-top: 0 !important;
-    padding-bottom: 0 !important;
+  }
+
+  .cell-values.tr {
+    align-items: stretch;
+
+    .td {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      height: revert;
+      padding: 5px
+    }
   }
 
 }


### PR DESCRIPTION
## Description

Sur la vue indicateur global, les cases du tableau prennent désormais toute la hauteur quoi qu'il arrive, malgré un nom de classe potentiellement long.

[PR - statistic-presences](https://github.com/OPEN-ENT-NG/presences/pull/283)