### PR TITLE
fix(calendar) : #MC-118 corrects CG77 timeslots css not being the right blue.

### DIFF
--- a/scss/specifics/calendar/components/calendar.scss
+++ b/scss/specifics/calendar/components/calendar.scss
@@ -156,7 +156,11 @@ calendar {
         }
     }
 
-    legend, .legend>.month-day, button.cyan {
+    legend, .legend>.month-day {
+        background: $calendar-blue !important;
+    }
+
+    button.cyan {
         background: $calendar-blue;
     }
 


### PR DESCRIPTION
A light blue replaced the regular blue for CG77 timeslots, so we put back the regular blue.