### PR TITLE
fix(folderTree): #LOOL-59 remove horizontal scrollBar in folder tree display

### DIFF
--- a/scss/specifics/lool-connector/_lool-connector.scss
+++ b/scss/specifics/lool-connector/_lool-connector.scss
@@ -29,6 +29,9 @@ body.lool {
         &-tree {
           max-height: 50vh;
           overflow-y: auto;
+          > ul {
+            box-sizing: border-box;
+          }
         }
       }
 


### PR DESCRIPTION
## Describe your changes
When we landed on lool, there was a horizontal scrollBar at the bottom of folderTree. 
This bug was due to an ul tag which width was bigger then its parent (nav) because the ul has an orange left-border that shifts its position to the right so the ul becomes wider than its parent.
To avoid this behaviour, i put a box-sizing border-box onto the ul to respect the size of its parent.
## Checklist tests
In ng2, type /lool endpoint and see if scrollbar is here.
## Issue ticket number and link

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)
