### PR TITLE
fix(eventZoom):MA-1093 fix calendar event display on zoom

### DIFF
--- a/scss/specifics/presences/components/containers/_calendar.scss
+++ b/scss/specifics/presences/components/containers/_calendar.scss
@@ -295,6 +295,10 @@ $calendar-user-card-height: 56px;
 
           .data > em.metadata {
             margin-right: 4px;
+            max-width: 20%;
+            text-overflow: ellipsis;
+            overflow: hidden;
+            white-space: nowrap;
           }
 
           &.contains-absence, &.contains-absenceReason {


### PR DESCRIPTION
Fixed an issue where events would disappear when zoomed in for classes with a classroom, because the classroom label would take up the space where the event was displayed. Now the classroom is cropped with "..."
[MA-1093](https://jira.support-ent.fr/browse/MA-1093)