### PR TITLE
feat(share): #FOR-626 add planet icon to form when public

### DIFF
--- a/scss/specifics/formulaire/components/_icon.scss
+++ b/scss/specifics/formulaire/components/_icon.scss
@@ -101,6 +101,11 @@ i {
     content: "\F09C";
   }
 
+  &.i-earth::before {
+    font-family: 'formulaire-mdi';
+    content: "\F1E7";
+  }
+
   &.i-cancel::before {
     font-family: 'formulaire-mdi';
     content: "\F156";


### PR DESCRIPTION
In list view, when a form was made to be public, a planet icon now appears in the right down border of form card.

This PR is related to 