### PR TITLE
fix(presences): #MA-1067 fix time-picker CSS on chrome

### DIFF
--- a/scss/specifics/presences/components/_init-1d-lightbox.scss
+++ b/scss/specifics/presences/components/_init-1d-lightbox.scss
@@ -1,8 +1,7 @@
 .init-1d-lightbox {
 
   .content {
-    width: 70%;
-
+    width: 75%;
 
     .init-1d-lightbox-body {
       padding: 20px;
@@ -42,6 +41,21 @@
         &-content {
           &-hours {
             margin: 8px 0;
+
+            .card {
+              padding: 4px;
+              margin-right: 8px;
+            }
+
+            .time-picker {
+              input[type="time"] {
+                height: 15px !important;
+              }
+              input[type="time"]::-webkit-calendar-picker-indicator {
+                background: none;
+                display: none;
+              }
+            }
           }
           &-days {
             display: flex;


### PR DESCRIPTION
- fix CSS of time-picker to remove the extra clock on the component

Before : 
![image](https://github.com/CGI-OPEN-ENT-NG/entcore-css-lib/assets/45894263/917d88cd-ddbe-4437-b2a6-91d7e2ab059e)

After : 

![image](https://github.com/CGI-OPEN-ENT-NG/entcore-css-lib/assets/45894263/17048eef-d155-46b4-8a62-0332f4f302ed)


