### PR TITLE
fix(statistics-presences): #MA-1089 fix refresh button

### DIFF
--- a/scss/specifics/statistics-presences/indicators/_global.scss
+++ b/scss/specifics/statistics-presences/indicators/_global.scss
@@ -74,4 +74,14 @@
     }
   }
 
+  .tbody {
+    .cell-values {
+      .td {
+        .audience {
+          display: inline;
+          padding-left: 5px;
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
Fix refresh icon and Class name overlap with class name too long.


Before : 
![image](https://github.com/CGI-OPEN-ENT-NG/entcore-css-lib/assets/57497688/fde106ee-a886-499d-bb0b-e36888d9f76e)

After :
![image](https://github.com/CGI-OPEN-ENT-NG/entcore-css-lib/assets/57497688/ca01a46e-ae34-4500-8176-86bd7ce479bc)

PR d'origine : https://github.com/OPEN-ENT-NG/presences/pull/325